### PR TITLE
feat: add refund and void transaction support

### DIFF
--- a/stripe_universal.php
+++ b/stripe_universal.php
@@ -353,6 +353,50 @@ class StripeUniversal extends NonmerchantGateway
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function refund($reference_id, $transaction_id, $amount, $notes = null)
+    {
+        $this->loadApi();
+
+        try {
+            // Retrieve PaymentIntent to get currency for amount conversion
+            $pi = \Stripe\PaymentIntent::retrieve($transaction_id);
+            $currency = strtoupper($pi->currency);
+            $amount_cents = $this->formatAmount($amount, $currency, 'to');
+
+            $this->log(
+                $this->base_url . 'refunds',
+                serialize(['payment_intent' => $transaction_id, 'amount' => $amount_cents]),
+                'input',
+                true
+            );
+
+            $refund = \Stripe\Refund::create([
+                'payment_intent' => $transaction_id,
+                'amount' => $amount_cents,
+            ]);
+
+            $this->log(
+                $this->base_url . 'refunds',
+                serialize($refund->toArray()),
+                'output',
+                true
+            );
+        } catch (\Stripe\Exception\ApiErrorException $e) {
+            $this->log($this->base_url . 'refunds', $e->getMessage(), 'output', false);
+            $this->Input->setErrors(['api' => ['internal' => $e->getMessage()]]);
+            return;
+        }
+
+        return [
+            'status' => 'refunded',
+            'reference_id' => $reference_id,
+            'transaction_id' => $transaction_id,
+        ];
+    }
+
+    /**
      * Retrieves the description for CC charges
      *
      * @param float total amount

--- a/stripe_universal.php
+++ b/stripe_universal.php
@@ -397,6 +397,44 @@ class StripeUniversal extends NonmerchantGateway
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function void($reference_id, $transaction_id, $notes = null)
+    {
+        $this->loadApi();
+
+        try {
+            $this->log(
+                $this->base_url . 'refunds - void',
+                serialize(['payment_intent' => $transaction_id]),
+                'input',
+                true
+            );
+
+            $refund = \Stripe\Refund::create([
+                'payment_intent' => $transaction_id,
+            ]);
+
+            $this->log(
+                $this->base_url . 'refunds - void',
+                serialize($refund->toArray()),
+                'output',
+                true
+            );
+        } catch (\Stripe\Exception\ApiErrorException $e) {
+            $this->log($this->base_url . 'refunds - void', $e->getMessage(), 'output', false);
+            $this->Input->setErrors(['api' => ['internal' => $e->getMessage()]]);
+            return;
+        }
+
+        return [
+            'status' => 'void',
+            'reference_id' => $reference_id,
+            'transaction_id' => $transaction_id,
+        ];
+    }
+
+    /**
      * Retrieves the description for CC charges
      *
      * @param float total amount

--- a/tests/Unit/RefundTest.php
+++ b/tests/Unit/RefundTest.php
@@ -1,0 +1,159 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests refund() — refunding a payment via Stripe Refund API.
+ */
+class RefundTest extends TestCase
+{
+    private $gateway;
+
+    protected function setUp(): void
+    {
+        // Preload Stripe class to prevent loadApi() fatal error
+        class_exists(\Stripe\Stripe::class);
+
+        MockHttpClient::reset();
+        \Stripe\ApiRequestor::setHttpClient(new MockHttpClient());
+        $this->gateway = new StripeUniversal();
+        $this->gateway->setMeta(['secret_key' => 'sk_test_123']);
+        $this->gateway->setCurrency('USD');
+    }
+
+    public function testRefundSuccess()
+    {
+        // First response: PaymentIntent::retrieve (to get currency)
+        MockHttpClient::enqueueResponse(json_encode([
+            'id' => 'pi_test_123',
+            'object' => 'payment_intent',
+            'currency' => 'usd',
+            'amount' => 1050,
+            'status' => 'succeeded',
+        ]));
+
+        // Second response: Refund::create
+        MockHttpClient::enqueueResponse(json_encode([
+            'id' => 're_test_123',
+            'object' => 'refund',
+            'amount' => 1050,
+            'currency' => 'usd',
+            'payment_intent' => 'pi_test_123',
+            'status' => 'succeeded',
+        ]));
+
+        $result = $this->gateway->refund('cs_test_ref', 'pi_test_123', 10.50);
+
+        $this->assertEquals('refunded', $result['status']);
+        $this->assertEquals('cs_test_ref', $result['reference_id']);
+        $this->assertEquals('pi_test_123', $result['transaction_id']);
+
+        // Verify two API calls were made (retrieve + create)
+        $requests = MockHttpClient::getAllRequests();
+        $this->assertCount(2, $requests);
+
+        // First call: PaymentIntent::retrieve (GET)
+        $this->assertEquals('get', $requests[0]['method']);
+        $this->assertStringContainsString('payment_intents/pi_test_123', $requests[0]['absUrl']);
+
+        // Second call: Refund::create (POST)
+        $this->assertEquals('post', $requests[1]['method']);
+        $this->assertStringContainsString('/v1/refunds', $requests[1]['absUrl']);
+    }
+
+    public function testPartialRefund()
+    {
+        // PaymentIntent::retrieve response
+        MockHttpClient::enqueueResponse(json_encode([
+            'id' => 'pi_test_partial',
+            'object' => 'payment_intent',
+            'currency' => 'usd',
+            'amount' => 3050,
+            'status' => 'succeeded',
+        ]));
+
+        // Refund::create response (partial)
+        MockHttpClient::enqueueResponse(json_encode([
+            'id' => 're_test_partial',
+            'object' => 'refund',
+            'amount' => 525,
+            'currency' => 'usd',
+            'payment_intent' => 'pi_test_partial',
+            'status' => 'succeeded',
+        ]));
+
+        $result = $this->gateway->refund('cs_test_ref', 'pi_test_partial', 5.25);
+
+        $this->assertEquals('refunded', $result['status']);
+
+        // Verify the amount was converted to cents (5.25 * 100 = 525)
+        // Note: $params is an array (Stripe SDK passes array to HttpClient, URL encoding happens in CurlClient)
+        $requests = MockHttpClient::getAllRequests();
+        $refundRequest = $requests[1]; // Second call is Refund::create
+        $this->assertEquals(525, $refundRequest['params']['amount']);
+    }
+
+    public function testRefundApiError()
+    {
+        // PaymentIntent::retrieve succeeds (needs currency for formatAmount)
+        MockHttpClient::enqueueResponse(json_encode([
+            'id' => 'pi_test_err',
+            'object' => 'payment_intent',
+            'currency' => 'usd',
+            'amount' => 1050,
+            'status' => 'succeeded',
+        ]));
+
+        // Refund::create returns error
+        MockHttpClient::enqueueResponse(json_encode([
+            'error' => [
+                'type' => 'invalid_request_error',
+                'message' => 'Charge ch_xxx has already been refunded.',
+            ],
+        ]), 400);
+
+        $result = $this->gateway->refund('cs_test_ref', 'pi_test_err', 10.50);
+
+        $this->assertNull($result);
+
+        $errors = $this->gateway->Input->errors();
+        $this->assertArrayHasKey('api', $errors);
+
+        // Verify error was logged with success=false
+        $logs = $this->gateway->getLogEntries();
+        $errorLog = end($logs);
+        $this->assertEquals('output', $errorLog['direction']);
+        $this->assertFalse($errorLog['success']);
+    }
+
+    public function testRefundZeroDecimalCurrency()
+    {
+        // PaymentIntent::retrieve returns JPY (zero-decimal currency)
+        MockHttpClient::enqueueResponse(json_encode([
+            'id' => 'pi_test_jpy',
+            'object' => 'payment_intent',
+            'currency' => 'jpy',
+            'amount' => 1000,
+            'status' => 'succeeded',
+        ]));
+
+        // Refund::create response
+        MockHttpClient::enqueueResponse(json_encode([
+            'id' => 're_test_jpy',
+            'object' => 'refund',
+            'amount' => 1000,
+            'currency' => 'jpy',
+            'payment_intent' => 'pi_test_jpy',
+            'status' => 'succeeded',
+        ]));
+
+        $result = $this->gateway->refund('cs_test_ref', 'pi_test_jpy', 1000);
+
+        $this->assertEquals('refunded', $result['status']);
+
+        // Verify JPY amount was NOT multiplied by 100 (zero-decimal currency)
+        $requests = MockHttpClient::getAllRequests();
+        $refundRequest = $requests[1];
+        $this->assertEquals(1000, $refundRequest['params']['amount']);
+    }
+}

--- a/tests/Unit/VoidTest.php
+++ b/tests/Unit/VoidTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests void() — voiding a payment (implemented as full refund via Stripe).
+ */
+class VoidTest extends TestCase
+{
+    private $gateway;
+
+    protected function setUp(): void
+    {
+        class_exists(\Stripe\Stripe::class);
+
+        MockHttpClient::reset();
+        \Stripe\ApiRequestor::setHttpClient(new MockHttpClient());
+        $this->gateway = new StripeUniversal();
+        $this->gateway->setMeta(['secret_key' => 'sk_test_123']);
+        // No setCurrency() needed — void() does not convert amounts
+    }
+
+    public function testVoidSuccess()
+    {
+        // Only one response needed: Refund::create (no PI retrieve for void)
+        MockHttpClient::enqueueResponse(json_encode([
+            'id' => 're_test_void',
+            'object' => 'refund',
+            'amount' => 1050,
+            'currency' => 'usd',
+            'payment_intent' => 'pi_test_void',
+            'status' => 'succeeded',
+        ]));
+
+        $result = $this->gateway->void('cs_test_ref', 'pi_test_void');
+
+        $this->assertEquals('void', $result['status']);
+        $this->assertEquals('cs_test_ref', $result['reference_id']);
+        $this->assertEquals('pi_test_void', $result['transaction_id']);
+
+        // Verify only one API call made (no PI retrieve needed)
+        $requests = MockHttpClient::getAllRequests();
+        $this->assertCount(1, $requests);
+
+        // Verify Refund::create was called without amount parameter
+        // Note: $params is an array (Stripe SDK passes array to HttpClient)
+        $this->assertEquals('post', $requests[0]['method']);
+        $this->assertStringContainsString('/v1/refunds', $requests[0]['absUrl']);
+        $this->assertArrayNotHasKey('amount', $requests[0]['params']);
+    }
+
+    public function testVoidApiError()
+    {
+        MockHttpClient::enqueueResponse(json_encode([
+            'error' => [
+                'type' => 'invalid_request_error',
+                'message' => 'No such payment_intent: pi_invalid',
+            ],
+        ]), 400);
+
+        $result = $this->gateway->void('cs_test_ref', 'pi_invalid');
+
+        $this->assertNull($result);
+
+        $errors = $this->gateway->Input->errors();
+        $this->assertArrayHasKey('api', $errors);
+
+        // Verify error was logged with success=false
+        $logs = $this->gateway->getLogEntries();
+        $errorLog = end($logs);
+        $this->assertEquals('output', $errorLog['direction']);
+        $this->assertFalse($errorLog['success']);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `refund()` method that processes refunds via Stripe's Refund API, with support for partial refunds and zero-decimal currencies (JPY, etc.)
- Add `void()` method that performs a full refund (Stripe doesn't support true voids for captured payments)
- Both methods include input/output logging and error handling matching existing gateway patterns

## Details

**refund()**: Retrieves the PaymentIntent first to obtain the currency (needed for correct amount conversion via `formatAmount()`), then calls `\Stripe\Refund::create()` with the converted amount.

**void()**: Calls `\Stripe\Refund::create()` without an amount parameter (full refund). No PaymentIntent retrieval needed since no amount conversion is required.

Both methods follow Blesta's `NonmerchantGateway` interface (`$reference_id`, `$transaction_id`, `$amount`, `$notes`).

## Test plan

- [x] `testRefundSuccess` — full refund happy path, verifies return array and 2 API calls (PI retrieve + refund create)
- [x] `testPartialRefund` — verifies amount conversion to cents (5.25 → 525)
- [x] `testRefundApiError` — verifies error handling (null return, Input errors, error logging with success=false)
- [x] `testRefundZeroDecimalCurrency` — verifies JPY amount not multiplied by 100
- [x] `testVoidSuccess` — full refund without amount param, verifies 1 API call only
- [x] `testVoidApiError` — verifies error handling matches refund pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)