### PR TITLE
feat: add async webhook support for delayed payment methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,13 @@ Checkout page support all payment methods (From Alipay, WeChat, Google Pay, Appl
 ## What it does
 
 - Generate `Stripe/Checkout/Session` checkout link and verify&record payment if completed
-- Partial webhook support (see below)
+- Webhook support for checkout completion and async payment methods (ACH, SEPA, etc.)
 - Separate items for multiple invoices checkout
 - Refund support (full and partial) via Stripe Refund API
 - Void transaction support (processed as full refund)
 
 ### TODO
 
-- Support webhook events but it does not handle async payment(ACH, etc.) for now. Webhook at this stage helps to capture payments that client failed to redirect back to website
 - Disable payment type in settings
 
 ## Install the Gateway

--- a/language/en_us/stripe_universal.php
+++ b/language/en_us/stripe_universal.php
@@ -17,6 +17,7 @@ $lang['StripeUniversal.!error.session_id.missing'] = 'Return URL missing session
 $lang['StripeUniversal.!error.payment_expired'] = 'Payment gateway returns that the current transaction has expired. Please re-checkout';
 $lang['StripeUniversal.!error.metadata.missing'] = 'Response is missing metadata, please open a support ticket for this transaction.';
 $lang['StripeUniversal.!error.metadata.missing_client_id'] = 'Payment gateway returns invalid metadata, please open a support ticket for this transaction.';
+$lang['StripeUniversal.!error.payment_async_failed'] = 'The delayed payment method was declined by the bank.';
 
 $lang['StripeUniversal.name'] = 'Stripe Universal';
 $lang['StripeUniversal.description'] = 'Uses Stripe Checkout to process payments.';
@@ -30,7 +31,7 @@ $lang['StripeUniversal.webhook_secret'] = 'Webhook Secret';
 $lang['StripeUniversal.tooltip_webhook_secret'] = 'When set, Gateway will try to verify the webhook request using the given secret.';
 
 $lang['StripeUniversal.webhook'] = 'Stripe Webhook';
-$lang['StripeUniversal.webhook_note'] = 'It is recommended to configure the following url as a Webhook for "checkout.session.completed" events in your Stripe account.';
+$lang['StripeUniversal.webhook_note'] = 'It is recommended to configure the following url as a Webhook for "checkout.session.completed", "checkout.session.async_payment_succeeded", and "checkout.session.async_payment_failed" events in your Stripe account.';
 
 // Charge description
 $lang['StripeUniversal.charge_description_default'] = 'Charge for specified amount';

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -25,7 +25,3 @@ parameters:
         -
             message: '#Parameter \#1 \$values of static method Stripe\\StripeObject::constructFrom\(\) expects array, string\|false given#'
             path: stripe_universal.php
-        # Unreachable break after return in switch case
-        -
-            message: '#Unreachable statement - code above always terminates#'
-            path: stripe_universal.php

--- a/stripe_universal.php
+++ b/stripe_universal.php
@@ -581,9 +581,11 @@ class StripeUniversal extends NonmerchantGateway
 
         switch ($event->type) {
             case 'checkout.session.completed':
+            case 'checkout.session.async_payment_succeeded':
                 return $this->handleCheckoutSession($event->data->object);
-                break;
-        };
+            case 'checkout.session.async_payment_failed':
+                return $this->handleAsyncPaymentFailed($event->data->object);
+        }
 
         return [];
     }

--- a/stripe_universal.php
+++ b/stripe_universal.php
@@ -253,6 +253,46 @@ class StripeUniversal extends NonmerchantGateway
         ];
     }
 
+    private function handleAsyncPaymentFailed(\Stripe\Checkout\Session $session)
+    {
+        $metadata = $this->extractMetadata($session->metadata);
+        if ($metadata === false) {
+            return [];
+        }
+
+        $this->Input->setErrors([
+            'payment_status' => [
+                'message' => Language::_('StripeUniversal.!error.payment_async_failed', true),
+            ]
+        ]);
+
+        if (isset($session->currency_conversion)) {
+            $currency = strtoupper($session->currency_conversion->source_currency);
+            $amount = $this->formatAmount(
+                $session->currency_conversion->amount_total,
+                $currency,
+                'from'
+            );
+        } else {
+            $currency = strtoupper($session->currency);
+            $amount = $this->formatAmount(
+                $session->amount_total,
+                $currency,
+                'from'
+            );
+        }
+
+        return [
+            'client_id' => $metadata['client_id'],
+            'amount' => $amount,
+            'currency' => $currency,
+            'status' => 'declined',
+            'reference_id' => $session->id,
+            'transaction_id' => $session->payment_intent,
+            'invoices' => $metadata['invoices'],
+        ];
+    }
+
     private function extractMetadata(\Stripe\StripeObject $metadata)
     {
         if ($metadata === null) {

--- a/tests/Unit/HandleAsyncPaymentFailedTest.php
+++ b/tests/Unit/HandleAsyncPaymentFailedTest.php
@@ -1,0 +1,115 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests handleAsyncPaymentFailed() via reflection.
+ * Validates that async payment failures return 'declined' status.
+ */
+class HandleAsyncPaymentFailedTest extends TestCase
+{
+    private $gateway;
+    private $method;
+
+    protected function setUp(): void
+    {
+        class_exists(\Stripe\Stripe::class);
+        MockHttpClient::reset();
+        \Stripe\ApiRequestor::setHttpClient(new MockHttpClient());
+        $this->gateway = new StripeUniversal();
+        $this->gateway->setMeta(['secret_key' => 'sk_test_123']);
+        $this->method = new ReflectionMethod(StripeUniversal::class, 'handleAsyncPaymentFailed');
+        $this->method->setAccessible(true);
+    }
+
+    private function makeSession(array $overrides = [])
+    {
+        $defaults = [
+            'id' => 'cs_test_async',
+            'object' => 'checkout.session',
+            'payment_status' => 'unpaid',
+            'status' => 'complete',
+            'currency' => 'usd',
+            'amount_total' => 2000,
+            'payment_intent' => 'pi_test_async',
+            'metadata' => [
+                'client_id' => 55,
+                'invoices' => base64_encode(serialize([['id' => 10, 'amount' => 20.00]])),
+            ],
+        ];
+        $data = array_merge($defaults, $overrides);
+        return \Stripe\Checkout\Session::constructFrom($data);
+    }
+
+    public function testDeclinedStatus()
+    {
+        $session = $this->makeSession();
+        $result = $this->method->invoke($this->gateway, $session);
+
+        $this->assertEquals('declined', $result['status']);
+        $this->assertEquals('cs_test_async', $result['reference_id']);
+        $this->assertEquals('pi_test_async', $result['transaction_id']);
+    }
+
+    public function testMetadataExtraction()
+    {
+        $invoices = [['id' => 10, 'amount' => 20.00]];
+        $session = $this->makeSession();
+        $result = $this->method->invoke($this->gateway, $session);
+
+        $this->assertEquals(55, $result['client_id']);
+        $this->assertEquals($invoices, $result['invoices']);
+    }
+
+    public function testAmountAndCurrency()
+    {
+        $session = $this->makeSession([
+            'currency' => 'eur',
+            'amount_total' => 1500,
+        ]);
+        $result = $this->method->invoke($this->gateway, $session);
+
+        $this->assertEquals('EUR', $result['currency']);
+        $this->assertEquals(15.00, $result['amount']);
+    }
+
+    public function testCurrencyConversion()
+    {
+        $session = $this->makeSession([
+            'currency' => 'eur',
+            'amount_total' => 1500,
+            'currency_conversion' => [
+                'source_currency' => 'usd',
+                'amount_total' => 1050,
+            ],
+        ]);
+        $result = $this->method->invoke($this->gateway, $session);
+
+        $this->assertEquals('USD', $result['currency']);
+        $this->assertEquals(10.50, $result['amount']);
+    }
+
+    public function testErrorMessageSet()
+    {
+        $session = $this->makeSession();
+        $this->method->invoke($this->gateway, $session);
+
+        $errors = $this->gateway->Input->errors();
+        $this->assertArrayHasKey('payment_status', $errors);
+    }
+
+    public function testMissingClientIdReturnsEmpty()
+    {
+        $session = $this->makeSession([
+            'metadata' => [
+                'client_id' => 0,
+                'invoices' => base64_encode(serialize([])),
+            ],
+        ]);
+        $result = $this->method->invoke($this->gateway, $session);
+
+        $this->assertEquals([], $result);
+        $errors = $this->gateway->Input->errors();
+        $this->assertArrayHasKey('metadata', $errors);
+    }
+}

--- a/tests/Unit/ValidateTest.php
+++ b/tests/Unit/ValidateTest.php
@@ -228,6 +228,74 @@ class ValidateTest extends TestCase
 
         $this->assertEquals([], $result);
     }
+
+    public function testAsyncPaymentSucceededEvent()
+    {
+        $payload = json_encode([
+            'id' => 'evt_test_async_ok',
+            'object' => 'event',
+            'type' => 'checkout.session.async_payment_succeeded',
+            'data' => [
+                'object' => [
+                    'id' => 'cs_test_async_ok',
+                    'object' => 'checkout.session',
+                    'payment_status' => 'paid',
+                    'status' => 'complete',
+                    'currency' => 'usd',
+                    'amount_total' => 3000,
+                    'payment_intent' => 'pi_test_async_ok',
+                    'metadata' => [
+                        'client_id' => 77,
+                        'invoices' => base64_encode(serialize([['id' => 5, 'amount' => 30.00]])),
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->setPhpInput($payload);
+        $_SERVER['HTTP_STRIPE_SIGNATURE'] = $this->generateSignatureHeader($payload, $this->webhookSecret);
+
+        $result = $this->gateway->validate([], []);
+
+        $this->assertEquals('approved', $result['status']);
+        $this->assertEquals(77, $result['client_id']);
+        $this->assertEquals(30.00, $result['amount']);
+    }
+
+    public function testAsyncPaymentFailedEvent()
+    {
+        $payload = json_encode([
+            'id' => 'evt_test_async_fail',
+            'object' => 'event',
+            'type' => 'checkout.session.async_payment_failed',
+            'data' => [
+                'object' => [
+                    'id' => 'cs_test_async_fail',
+                    'object' => 'checkout.session',
+                    'payment_status' => 'unpaid',
+                    'status' => 'complete',
+                    'currency' => 'usd',
+                    'amount_total' => 5000,
+                    'payment_intent' => 'pi_test_async_fail',
+                    'metadata' => [
+                        'client_id' => 88,
+                        'invoices' => base64_encode(serialize([['id' => 7, 'amount' => 50.00]])),
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->setPhpInput($payload);
+        $_SERVER['HTTP_STRIPE_SIGNATURE'] = $this->generateSignatureHeader($payload, $this->webhookSecret);
+
+        $result = $this->gateway->validate([], []);
+
+        $this->assertEquals('declined', $result['status']);
+        $this->assertEquals(88, $result['client_id']);
+        $this->assertEquals(50.00, $result['amount']);
+        $errors = $this->gateway->Input->errors();
+        $this->assertArrayHasKey('payment_status', $errors);
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Handle `checkout.session.async_payment_succeeded` and `checkout.session.async_payment_failed` Stripe webhook events
- Add `handleAsyncPaymentFailed()` method returning `'declined'` status for failed async payments (ACH, SEPA, etc.)
- Reuse existing `handleCheckoutSession()` for `async_payment_succeeded` (payment_status is already `'paid'`)
- Update webhook note to recommend subscribing to all three event types
- Remove partial webhook TODO from README

## Test plan
- [x] 6 new unit tests for `handleAsyncPaymentFailed()` (status, metadata, currency, conversion, error, missing client_id)
- [x] 2 new routing tests in `ValidateTest` (end-to-end webhook flow for both async event types)
- [x] All 71 tests pass
- [x] PHPStan level 5 clean
- [x] php-cs-fixer clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)