### PR TITLE
fix: harden webhooks and refund status handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,14 @@ For example:
 2. Navigate to `Settings > Payment Gateways`
 3. Find the Stripe Universal gateway
 4. Click the "Install" button
-5. Profit!
+5. Configure the Stripe API secret and webhook signing secret
+
+The webhook endpoint must subscribe to `checkout.session.completed`,
+`checkout.session.async_payment_succeeded`, and
+`checkout.session.async_payment_failed` events.
+
+After upgrading an existing installation to 1.1.0, save the gateway settings
+once to encrypt a webhook secret that was stored by an earlier release.
 
 ## Customize the plugin
 

--- a/language/en_us/stripe_universal.php
+++ b/language/en_us/stripe_universal.php
@@ -4,6 +4,7 @@
 $lang['StripeUniversal.!error.auth'] = 'The gateway could not authenticate.';
 $lang['StripeUniversal.!error.secret_key.empty'] = 'Please enter a Secret Key.';
 $lang['StripeUniversal.!error.secret_key.valid'] = 'Unable to connect to the Stripe API using the given Secret Key.';
+$lang['StripeUniversal.!error.webhook_secret.empty'] = 'Please enter a Webhook Secret.';
 
 $lang['StripeUniversal.!error.invalid_request_error'] = 'The payment gateway returned an error when processing the request.';
 
@@ -28,7 +29,7 @@ $lang['StripeUniversal.test_key_detected'] = 'You are currently using Test Key! 
 $lang['StripeUniversal.tooltip_secret_key'] = 'Your API Secret Key is specific to either live or test mode. Be sure you are using the correct key.';
 
 $lang['StripeUniversal.webhook_secret'] = 'Webhook Secret';
-$lang['StripeUniversal.tooltip_webhook_secret'] = 'When set, Gateway will try to verify the webhook request using the given secret.';
+$lang['StripeUniversal.tooltip_webhook_secret'] = 'Used to verify that webhook requests were sent by Stripe.';
 
 $lang['StripeUniversal.webhook'] = 'Stripe Webhook';
 $lang['StripeUniversal.webhook_note'] = 'It is recommended to configure the following url as a Webhook for "checkout.session.completed", "checkout.session.async_payment_succeeded", and "checkout.session.async_payment_failed" events in your Stripe account.';

--- a/stripe_universal.php
+++ b/stripe_universal.php
@@ -74,6 +74,13 @@ class StripeUniversal extends NonmerchantGateway
                     'rule' => [[$this, 'validateConnection']],
                     'message' => Language::_('StripeUniversal.!error.secret_key.valid', true)
                 ]
+            ],
+            'webhook_secret' => [
+                'empty' => [
+                    'rule' => 'isEmpty',
+                    'negate' => true,
+                    'message' => Language::_('StripeUniversal.!error.webhook_secret.empty', true)
+                ]
             ]
         ];
 
@@ -90,7 +97,7 @@ class StripeUniversal extends NonmerchantGateway
      */
     public function encryptableFields()
     {
-        return ['secret_key'];
+        return ['secret_key', 'webhook_secret'];
     }
 
     /**
@@ -189,7 +196,7 @@ class StripeUniversal extends NonmerchantGateway
         return [];
     }
 
-    private function handleCheckoutSession(\Stripe\StripeObject $session)
+    private function handleCheckoutSession(\Stripe\Checkout\Session $session)
     {
         $status = 'pending';
         if ($session->payment_status === 'paid') {
@@ -255,7 +262,7 @@ class StripeUniversal extends NonmerchantGateway
         ];
     }
 
-    private function handleAsyncPaymentFailed(\Stripe\StripeObject $session)
+    private function handleAsyncPaymentFailed(\Stripe\Checkout\Session $session)
     {
         $metadata = $this->extractMetadata($session->metadata);
         if ($metadata === false) {
@@ -367,6 +374,19 @@ class StripeUniversal extends NonmerchantGateway
         return (int)round($amount);
     }
 
+    private function mapRefundStatus($stripeStatus, $completedStatus)
+    {
+        if ($stripeStatus === 'succeeded') {
+            return $completedStatus;
+        }
+
+        if (in_array($stripeStatus, ['pending', 'requires_action'], true)) {
+            return 'pending';
+        }
+
+        return 'declined';
+    }
+
 
     /**
      * Checks whether a key can be used to connect to the Stripe API
@@ -433,7 +453,7 @@ class StripeUniversal extends NonmerchantGateway
         }
 
         return [
-            'status' => 'refunded',
+            'status' => $this->mapRefundStatus($refund->status, 'refunded'),
             'reference_id' => $reference_id,
             'transaction_id' => $transaction_id,
         ];
@@ -471,7 +491,7 @@ class StripeUniversal extends NonmerchantGateway
         }
 
         return [
-            'status' => 'void',
+            'status' => $this->mapRefundStatus($refund->status, 'void'),
             'reference_id' => $reference_id,
             'transaction_id' => $transaction_id,
         ];
@@ -554,17 +574,27 @@ class StripeUniversal extends NonmerchantGateway
         $payload = @file_get_contents('php://input');
         $sig_header = $_SERVER['HTTP_STRIPE_SIGNATURE'] ?? null;
 
+        $webhook_secret = $this->meta['webhook_secret'] ?? null;
+        if (!$webhook_secret) {
+            $this->log($this->base_url . 'Webhook - missing_secret', 'Webhook secret is not configured');
+            $this->Input->setErrors(['event' => ['internal' => 'missing_secret']]);
+
+            return [];
+        }
+
+        if (!is_string($sig_header) || trim($sig_header) === '') {
+            $this->log($this->base_url . 'Webhook - invalid_signature', 'Stripe-Signature header is missing');
+            $this->Input->setErrors(['event' => ['internal' => 'invalid_signature']]);
+
+            return [];
+        }
+
         try {
-            $webhook_secret = $this->meta['webhook_secret'] ?? null;
-            if ($webhook_secret) {
-                $event = Stripe\Webhook::constructEvent(
-                    $payload,
-                    $sig_header,
-                    $webhook_secret
-                );
-            } else {
-                $event = \Stripe\Event::constructFrom($payload);
-            }
+            $event = Stripe\Webhook::constructEvent(
+                $payload,
+                $sig_header,
+                $webhook_secret
+            );
         } catch (\Stripe\Exception\SignatureVerificationException $e) {
             $this->log($this->base_url . 'Webhook - invalid_signature', $e->getMessage());
             $this->Input->setErrors(['event' => ['internal' => 'invalid_signature']]);
@@ -575,19 +605,32 @@ class StripeUniversal extends NonmerchantGateway
             $this->Input->setErrors(['event' => ['internal' => 'invalid_payload']]);
 
             return [];
-        } catch (Exception $e) {
-            $this->log($this->base_url . 'Webhook - unknown', $e->getMessage());
-            $this->Input->setErrors(['event' => ['internal' => 'unknown']]);
-
-            return [];
         }
 
-        switch ($event->type) {
-            case 'checkout.session.completed':
-            case 'checkout.session.async_payment_succeeded':
-                return $this->handleCheckoutSession($event->data->object);
-            case 'checkout.session.async_payment_failed':
-                return $this->handleAsyncPaymentFailed($event->data->object);
+        $sessionEventTypes = [
+            'checkout.session.completed',
+            'checkout.session.async_payment_succeeded',
+            'checkout.session.async_payment_failed',
+        ];
+        if (in_array($event->type, $sessionEventTypes, true)) {
+            $session = $event->data->object ?? null;
+            if (!($session instanceof \Stripe\Checkout\Session)) {
+                $this->log(
+                    $this->base_url . 'Webhook - invalid_object',
+                    serialize(['event_id' => $event->id, 'event_type' => $event->type])
+                );
+                $this->Input->setErrors(['event' => ['internal' => 'invalid_object']]);
+
+                return [];
+            }
+
+            switch ($event->type) {
+                case 'checkout.session.completed':
+                case 'checkout.session.async_payment_succeeded':
+                    return $this->handleCheckoutSession($session);
+                case 'checkout.session.async_payment_failed':
+                    return $this->handleAsyncPaymentFailed($session);
+            }
         }
 
         return [];

--- a/tests/Unit/EditSettingsTest.php
+++ b/tests/Unit/EditSettingsTest.php
@@ -18,7 +18,7 @@ class EditSettingsTest extends TestCase
 
     public function testSetsValidationRules()
     {
-        $meta = ['secret_key' => 'sk_test_abc'];
+        $meta = ['secret_key' => 'sk_test_abc', 'webhook_secret' => 'whsec_123'];
         $this->gateway->editSettings($meta);
 
         $rules = $this->gateway->Input->getRules();
@@ -26,6 +26,8 @@ class EditSettingsTest extends TestCase
         $this->assertArrayHasKey('secret_key', $rules);
         $this->assertArrayHasKey('empty', $rules['secret_key']);
         $this->assertArrayHasKey('valid', $rules['secret_key']);
+        $this->assertArrayHasKey('webhook_secret', $rules);
+        $this->assertArrayHasKey('empty', $rules['webhook_secret']);
 
         // Verify the 'empty' rule structure
         $this->assertEquals('isEmpty', $rules['secret_key']['empty']['rule']);
@@ -33,6 +35,8 @@ class EditSettingsTest extends TestCase
 
         // Verify the 'valid' rule references validateConnection
         $this->assertIsArray($rules['secret_key']['valid']['rule']);
+        $this->assertEquals('isEmpty', $rules['webhook_secret']['empty']['rule']);
+        $this->assertTrue($rules['webhook_secret']['empty']['negate']);
     }
 
     public function testReturnsMeta()

--- a/tests/Unit/RefundTest.php
+++ b/tests/Unit/RefundTest.php
@@ -156,4 +156,23 @@ class RefundTest extends TestCase
         $refundRequest = $requests[1];
         $this->assertEquals(1000, $refundRequest['params']['amount']);
     }
+
+    public function testPendingRefundRemainsPending()
+    {
+        MockHttpClient::enqueueResponse(json_encode([
+            'id' => 'pi_test_pending',
+            'object' => 'payment_intent',
+            'currency' => 'usd',
+        ]));
+        MockHttpClient::enqueueResponse(json_encode([
+            'id' => 're_test_pending',
+            'object' => 'refund',
+            'payment_intent' => 'pi_test_pending',
+            'status' => 'pending',
+        ]));
+
+        $result = $this->gateway->refund('cs_test_ref', 'pi_test_pending', 10.50);
+
+        $this->assertSame('pending', $result['status']);
+    }
 }

--- a/tests/Unit/TrivialMethodsTest.php
+++ b/tests/Unit/TrivialMethodsTest.php
@@ -15,7 +15,7 @@ class TrivialMethodsTest extends TestCase
 
     public function testEncryptableFields()
     {
-        $this->assertEquals(['secret_key'], $this->gateway->encryptableFields());
+        $this->assertEquals(['secret_key', 'webhook_secret'], $this->gateway->encryptableFields());
     }
 
     public function testRequiresCustomerPresent()

--- a/tests/Unit/ValidateTest.php
+++ b/tests/Unit/ValidateTest.php
@@ -109,6 +109,18 @@ class ValidateTest extends TestCase
         $this->assertEquals('invalid_signature', $errors['event']['internal']);
     }
 
+    public function testMissingSignatureHeader()
+    {
+        $payload = json_encode(['id' => 'evt_test', 'type' => 'checkout.session.completed']);
+        $this->setPhpInput($payload);
+
+        $result = $this->gateway->validate([], []);
+
+        $this->assertSame([], $result);
+        $errors = $this->gateway->Input->errors();
+        $this->assertSame('invalid_signature', $errors['event']['internal']);
+    }
+
     public function testInvalidPayload()
     {
         $this->setPhpInput('not valid json {{{');
@@ -123,41 +135,6 @@ class ValidateTest extends TestCase
         $this->assertContains($errors['event']['internal'], ['invalid_signature', 'invalid_payload']);
     }
 
-    /**
-     * Tests the generic Exception catch block.
-     * Triggered by the Event::constructFrom path (no webhook_secret) receiving
-     * a raw string instead of an array — a pre-existing bug.
-     * PHP 7: catch(Exception) catches the error, returns [] with error set.
-     * PHP 8+: TypeError extends Error (not Exception), so it propagates uncaught.
-     */
-    public function testGenericException()
-    {
-        $this->gateway->setMeta([
-            'secret_key' => 'sk_test_123',
-            // no webhook_secret
-        ]);
-
-        $this->setPhpInput('{"not": "a valid event"}');
-
-        if (PHP_MAJOR_VERSION >= 8) {
-            $this->expectException(\TypeError::class);
-            $this->gateway->validate([], []);
-        } else {
-            // PHP 7: caught by catch(Exception), returns [] with error
-            $result = $this->gateway->validate([], []);
-            $this->assertEquals([], $result);
-            $errors = $this->gateway->Input->errors();
-            $this->assertArrayHasKey('event', $errors);
-        }
-    }
-
-    /**
-     * Tests the fallback path when no webhook_secret is configured.
-     * Documents pre-existing bug: Event::constructFrom receives a raw string
-     * instead of an array, which the real Stripe SDK does not handle correctly.
-     * PHP 7: catch(Exception) catches the error, returns [] with error set.
-     * PHP 8+: TypeError extends Error (not Exception), so it propagates uncaught.
-     */
     public function testWebhookWithoutSecret()
     {
         $this->gateway->setMeta([
@@ -168,15 +145,11 @@ class ValidateTest extends TestCase
         $payload = '{"id":"evt_test","type":"checkout.session.completed","data":{"object":{"id":"cs_xxx"}}}';
         $this->setPhpInput($payload);
 
-        if (PHP_MAJOR_VERSION >= 8) {
-            $this->expectException(\TypeError::class);
-            $this->gateway->validate([], []);
-        } else {
-            $result = $this->gateway->validate([], []);
-            $this->assertEquals([], $result);
-            $errors = $this->gateway->Input->errors();
-            $this->assertArrayHasKey('event', $errors);
-        }
+        $result = $this->gateway->validate([], []);
+
+        $this->assertSame([], $result);
+        $errors = $this->gateway->Input->errors();
+        $this->assertSame('missing_secret', $errors['event']['internal']);
     }
 
     public function testCheckoutSessionCompletedEvent()
@@ -227,6 +200,58 @@ class ValidateTest extends TestCase
         $result = $this->gateway->validate([], []);
 
         $this->assertEquals([], $result);
+    }
+
+    public function testCheckoutEventRejectsUnexpectedObjectType()
+    {
+        $payload = json_encode([
+            'id' => 'evt_test_wrong_object',
+            'object' => 'event',
+            'type' => 'checkout.session.completed',
+            'data' => [
+                'object' => [
+                    'id' => 'pi_wrong_object',
+                    'object' => 'payment_intent',
+                    'description' => 'sensitive@example.com',
+                ],
+            ],
+        ]);
+
+        $this->setPhpInput($payload);
+        $_SERVER['HTTP_STRIPE_SIGNATURE'] = $this->generateSignatureHeader($payload, $this->webhookSecret);
+
+        $result = $this->gateway->validate([], []);
+
+        $this->assertSame([], $result);
+        $errors = $this->gateway->Input->errors();
+        $this->assertSame('invalid_object', $errors['event']['internal']);
+        $logs = $this->gateway->getLogEntries();
+        $this->assertSame(
+            serialize([
+                'event_id' => 'evt_test_wrong_object',
+                'event_type' => 'checkout.session.completed',
+            ]),
+            end($logs)['data']
+        );
+    }
+
+    public function testCheckoutEventRejectsMissingObject()
+    {
+        $payload = json_encode([
+            'id' => 'evt_test_missing_object',
+            'object' => 'event',
+            'type' => 'checkout.session.completed',
+            'data' => [],
+        ]);
+
+        $this->setPhpInput($payload);
+        $_SERVER['HTTP_STRIPE_SIGNATURE'] = $this->generateSignatureHeader($payload, $this->webhookSecret);
+
+        $result = $this->gateway->validate([], []);
+
+        $this->assertSame([], $result);
+        $errors = $this->gateway->Input->errors();
+        $this->assertSame('invalid_object', $errors['event']['internal']);
     }
 
     public function testAsyncPaymentSucceededEvent()

--- a/tests/Unit/VoidTest.php
+++ b/tests/Unit/VoidTest.php
@@ -71,4 +71,19 @@ class VoidTest extends TestCase
         $this->assertEquals('output', $errorLog['direction']);
         $this->assertFalse($errorLog['success']);
     }
+
+    public function testFailedVoidIsDeclined()
+    {
+        MockHttpClient::enqueueResponse(json_encode([
+            'id' => 're_test_failed_void',
+            'object' => 'refund',
+            'payment_intent' => 'pi_test_failed_void',
+            'status' => 'failed',
+            'failure_reason' => 'declined',
+        ]));
+
+        $result = $this->gateway->void('cs_test_ref', 'pi_test_failed_void');
+
+        $this->assertSame('declined', $result['status']);
+    }
 }


### PR DESCRIPTION
## Summary

- Require and encrypt the Stripe webhook signing secret, and reject unsigned webhook payloads when it is missing.
- Reject missing signature headers and malformed Checkout event objects without raising webhook endpoint errors.
- Limit malformed-event logs to the Stripe event ID and type so customer data is not retained.
- Validate that Checkout webhook events contain a Checkout Session before dispatching them.
- Map Stripe refund and void outcomes to Blesta pending, completed, or declined statuses.
- Document the webhook setup and migration step, with focused unit coverage.

## Context

This follows the Stripe SDK upgrade in #15. The diff is intentionally limited to behavioral hardening and its tests.

## Verification

- PHPUnit: 75 tests, 181 assertions
- PHPStan: clean
- PHP CS Fixer: clean
- Composer validation: clean
- Composer audit: no known advisories

## Out of Scope

Refund idempotency remains unchanged. The Blesta gateway callback does not provide a stable refund-attempt identifier, and deriving one from transaction plus amount would incorrectly block legitimate repeated equal partial refunds.
