### PR TITLE
fix: make checkout session retries idempotent

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ The webhook endpoint must subscribe to `checkout.session.completed`,
 After upgrading an existing installation to 1.1.0, save the gateway settings
 once to encrypt a webhook secret that was stored by an earlier release.
 
+### Checkout Session lifecycle
+
+Stripe recommends creating a Checkout Session for each payment attempt. This
+gateway follows that model because Blesta's `buildProcess` interface provides
+the contact, amount, invoices, and redirect options, but no durable
+payment-attempt identifier or gateway-owned storage. Reusing a session by
+matching those values could send two legitimate attempts to the same session.
+
+Creating a session uses an idempotency key and two Stripe SDK-managed network
+retries. That protects a temporary transport failure during one `buildProcess`
+call, but intentionally does not reuse sessions across later visits or retries
+initiated by Blesta. Safe cross-request reuse requires a Blesta payment-attempt
+ID, persistent session storage, and validation of the invoice set, amount,
+currency, customer, session status, and expiration.
+
 ## Customize the plugin
 
 Here are some tips if you want to customize/setup this plugin

--- a/stripe_universal.php
+++ b/stripe_universal.php
@@ -137,8 +137,10 @@ class StripeUniversal extends NonmerchantGateway
         Loader::loadModels($this, ['Contacts']);
         $contact = $this->Contacts->get($contact_info['id']);
 
-        // Create Payment Session for user to jump to
-        // FIXME: Find a way to reuse existing session instead of creating one every time
+        // Create a distinct session for each payment attempt. The Blesta
+        // buildProcess() contract has no durable payment-attempt identifier or
+        // gateway storage hook, so matching its inputs would merge legitimate
+        // attempts for the same invoices. See README.md for the required design.
         try {
             $sessionObj = [
                 'customer_email' => $contact->email,
@@ -151,7 +153,17 @@ class StripeUniversal extends NonmerchantGateway
                     'invoices' => base64_encode(serialize($invoice_amounts)),
                 ]
             ];
-            $session = \Stripe\Checkout\Session::create($sessionObj);
+            $stripe = new \Stripe\StripeClient([
+                'api_key' => $this->meta['secret_key'],
+                'stripe_version' => self::STRIPE_API_VERSION,
+                'max_network_retries' => 2,
+            ]);
+            $session = $stripe->checkout->sessions->create($sessionObj, [
+                // This key is only reused by Stripe SDK retries for this request.
+                // It must not be derived from invoice data, which may represent a
+                // separate payment attempt.
+                'idempotency_key' => 'stripe-universal-checkout-' . bin2hex(random_bytes(16)),
+            ]);
         } catch (Exception $e) {
             $this->Input->setErrors(['api' => ['internal' => $e->getMessage()]]);
             return;

--- a/tests/Unit/BuildProcessTest.php
+++ b/tests/Unit/BuildProcessTest.php
@@ -64,6 +64,41 @@ class BuildProcessTest extends TestCase
         $this->assertStringContainsString('checkout/sessions', $lastRequest['absUrl']);
         $this->assertSame('v1', $lastRequest['apiMode']);
         $this->assertContains('Stripe-Version: 2024-04-10', $lastRequest['headers']);
+        $this->assertSame(2, $lastRequest['maxNetworkRetries']);
+        $this->assertMatchesRegularExpression(
+            '/^Idempotency-Key: stripe-universal-checkout-[a-f0-9]{32}$/',
+            $this->getHeader($lastRequest['headers'], 'Idempotency-Key')
+        );
+    }
+
+    public function testBuildProcessCreatesDistinctSessionsForDistinctAttempts()
+    {
+        MockHttpClient::enqueueResponse(json_encode([
+            'id' => 'cs_test_first',
+            'object' => 'checkout.session',
+            'url' => 'https://checkout.stripe.com/pay/cs_test_first',
+        ]));
+        MockHttpClient::enqueueResponse(json_encode([
+            'id' => 'cs_test_second',
+            'object' => 'checkout.session',
+            'url' => 'https://checkout.stripe.com/pay/cs_test_second',
+        ]));
+
+        $arguments = [
+            ['id' => 1, 'client_id' => 42],
+            10.50,
+            [['id' => 1, 'amount' => 10.50]],
+            ['return_url' => 'https://example.com/return'],
+        ];
+        $this->gateway->buildProcess(...$arguments);
+        $this->gateway->buildProcess(...$arguments);
+
+        $requests = MockHttpClient::getAllRequests();
+        $this->assertCount(2, $requests);
+        $this->assertNotSame(
+            $this->getHeader($requests[0]['headers'], 'Idempotency-Key'),
+            $this->getHeader($requests[1]['headers'], 'Idempotency-Key')
+        );
     }
 
     public function testBuildProcessApiError()
@@ -86,5 +121,16 @@ class BuildProcessTest extends TestCase
         $this->assertNull($result);
         $errors = $this->gateway->Input->errors();
         $this->assertArrayHasKey('api', $errors);
+    }
+
+    private function getHeader(array $headers, string $name): string
+    {
+        foreach ($headers as $header) {
+            if (strpos($header, $name . ': ') === 0) {
+                return $header;
+            }
+        }
+
+        $this->fail('Expected ' . $name . ' header was not sent.');
     }
 }

--- a/tests/Unit/BuildProcessTest.php
+++ b/tests/Unit/BuildProcessTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -132,6 +133,6 @@ class BuildProcessTest extends TestCase
             }
         }
 
-        $this->fail('Expected ' . $name . ' header was not sent.');
+        throw new AssertionFailedError('Expected ' . $name . ' header was not sent.');
     }
 }


### PR DESCRIPTION
## Summary

- replace the unsafe Checkout Session reuse FIXME with the documented payment-attempt lifecycle
- create Checkout Sessions through StripeClient with two SDK-managed network retries
- attach one request-scoped idempotency key so transport retries cannot create duplicate Sessions
- preserve distinct Sessions and keys for separate Blesta payment attempts

## Design

Blesta buildProcess provides payment inputs but no durable payment-attempt identifier or gateway-owned storage. Reusing Sessions by invoice, amount, currency, or customer would merge legitimate separate attempts. This change therefore limits idempotency to retries within one invocation and documents what cross-request reuse would require.

## Verification

- PHPUnit: 76 tests passed
- PHPStan: clean
- PHP syntax check: clean
- PHP CS Fixer: clean

