### PR TITLE
fix: retry refund requests safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@ Checkout page support all payment methods (From Alipay, WeChat, Google Pay, Appl
 - Refund support (full and partial) via Stripe Refund API
 - Void transaction support (processed as full refund)
 
+### Refund retries
+
+Each refund and void invocation supplies one Stripe idempotency key and ensures
+Stripe PHP is configured for at least two retries on transient network failures.
+The key is unique to that invocation, which prevents duplicate refunds during it
+while allowing legitimate equal-value partial refunds later.
+
+Blesta's gateway callback does not provide a persistent refund-attempt ID, so
+an administrator retrying a request after the original invocation has ended is
+not deduplicated by this gateway. Resolve an ambiguous result in Stripe before
+retrying it manually.
+
 ### TODO
 
 - Disable payment type in settings

--- a/stripe_universal.php
+++ b/stripe_universal.php
@@ -8,6 +8,7 @@
 class StripeUniversal extends NonmerchantGateway
 {
     private const STRIPE_API_VERSION = '2024-04-10';
+    private const REFUND_NETWORK_RETRIES = 2;
 
     /**
      * @var array An array of meta data for this gateway
@@ -387,6 +388,39 @@ class StripeUniversal extends NonmerchantGateway
         return 'declined';
     }
 
+    /**
+     * Creates a refund with a request-scoped idempotency key.
+     *
+     * Blesta does not supply a unique refund-attempt ID to gateway callbacks, so
+     * this key intentionally covers only Stripe's automatic retries for this
+     * invocation. A later, separate partial refund must receive a new key.
+     * Stripe PHP 21's legacy static API reads the retry count from global state,
+     * rather than the request options used by StripeClient, so restore it after
+     * the request completes.
+     *
+     * @param array $params Stripe Refund create parameters
+     * @return \Stripe\Refund
+     */
+    private function createRefund(array $params)
+    {
+        try {
+            $idempotencyKey = 'blesta-refund-' . bin2hex(random_bytes(16));
+        } catch (\Exception $e) {
+            throw new \RuntimeException('Unable to generate a Stripe idempotency key.', 0, $e);
+        }
+
+        $previousRetries = \Stripe\Stripe::getMaxNetworkRetries();
+        \Stripe\Stripe::setMaxNetworkRetries(max($previousRetries, self::REFUND_NETWORK_RETRIES));
+
+        try {
+            return \Stripe\Refund::create($params, [
+                'idempotency_key' => $idempotencyKey,
+            ]);
+        } finally {
+            \Stripe\Stripe::setMaxNetworkRetries($previousRetries);
+        }
+    }
+
 
     /**
      * Checks whether a key can be used to connect to the Stripe API
@@ -435,7 +469,7 @@ class StripeUniversal extends NonmerchantGateway
                 true
             );
 
-            $refund = \Stripe\Refund::create([
+            $refund = $this->createRefund([
                 'payment_intent' => $transaction_id,
                 'amount' => $amount_cents,
             ]);
@@ -446,7 +480,7 @@ class StripeUniversal extends NonmerchantGateway
                 'output',
                 true
             );
-        } catch (\Stripe\Exception\ApiErrorException $e) {
+        } catch (\Stripe\Exception\ApiErrorException | \RuntimeException $e) {
             $this->log($this->base_url . 'refunds', $e->getMessage(), 'output', false);
             $this->Input->setErrors(['api' => ['internal' => $e->getMessage()]]);
             return;
@@ -474,7 +508,7 @@ class StripeUniversal extends NonmerchantGateway
                 true
             );
 
-            $refund = \Stripe\Refund::create([
+            $refund = $this->createRefund([
                 'payment_intent' => $transaction_id,
             ]);
 
@@ -484,7 +518,7 @@ class StripeUniversal extends NonmerchantGateway
                 'output',
                 true
             );
-        } catch (\Stripe\Exception\ApiErrorException $e) {
+        } catch (\Stripe\Exception\ApiErrorException | \RuntimeException $e) {
             $this->log($this->base_url . 'refunds - void', $e->getMessage(), 'output', false);
             $this->Input->setErrors(['api' => ['internal' => $e->getMessage()]]);
             return;

--- a/tests/MockHttpClient.php
+++ b/tests/MockHttpClient.php
@@ -45,6 +45,9 @@ class MockHttpClient implements \Stripe\HttpClient\ClientInterface
             'apiMode',
             'maxNetworkRetries'
         );
+        $lastRequest = count(self::$requestLog) - 1;
+        self::$requestLog[$lastRequest]['configuredMaxNetworkRetries'] =
+            \Stripe\Stripe::getMaxNetworkRetries();
 
         if (!empty(self::$responseQueue)) {
             return array_shift(self::$responseQueue);

--- a/tests/Unit/RefundTest.php
+++ b/tests/Unit/RefundTest.php
@@ -8,17 +8,26 @@ use PHPUnit\Framework\TestCase;
 class RefundTest extends TestCase
 {
     private $gateway;
+    private $originalMaxNetworkRetries;
 
     protected function setUp(): void
     {
         // Preload Stripe class to prevent loadApi() fatal error
         class_exists(\Stripe\Stripe::class);
 
+        $this->originalMaxNetworkRetries = \Stripe\Stripe::getMaxNetworkRetries();
+        \Stripe\Stripe::setMaxNetworkRetries(1);
+
         MockHttpClient::reset();
         \Stripe\ApiRequestor::setHttpClient(new MockHttpClient());
         $this->gateway = new StripeUniversal();
         $this->gateway->setMeta(['secret_key' => 'sk_test_123']);
         $this->gateway->setCurrency('USD');
+    }
+
+    protected function tearDown(): void
+    {
+        \Stripe\Stripe::setMaxNetworkRetries($this->originalMaxNetworkRetries);
     }
 
     public function testRefundSuccess()
@@ -116,7 +125,7 @@ class RefundTest extends TestCase
             '/^blesta-refund-[a-f0-9]{32}$/',
             $idempotencyKey
         );
-        $this->assertSame(0, \Stripe\Stripe::getMaxNetworkRetries());
+        $this->assertSame(1, \Stripe\Stripe::getMaxNetworkRetries());
     }
 
     public function testEqualPartialRefundAttemptsUseDifferentIdempotencyKeys()
@@ -183,7 +192,7 @@ class RefundTest extends TestCase
 
         $errors = $this->gateway->Input->errors();
         $this->assertArrayHasKey('api', $errors);
-        $this->assertSame(0, \Stripe\Stripe::getMaxNetworkRetries());
+        $this->assertSame(1, \Stripe\Stripe::getMaxNetworkRetries());
 
         // Verify error was logged with success=false
         $logs = $this->gateway->getLogEntries();

--- a/tests/Unit/RefundTest.php
+++ b/tests/Unit/RefundTest.php
@@ -93,6 +93,71 @@ class RefundTest extends TestCase
         $this->assertEquals(525, $refundRequest['params']['amount']);
     }
 
+    public function testRefundConfiguresRequestScopedIdempotencyAndRetries()
+    {
+        MockHttpClient::enqueueResponse(json_encode([
+            'id' => 'pi_test_retry',
+            'object' => 'payment_intent',
+            'currency' => 'usd',
+        ]));
+        MockHttpClient::enqueueResponse(json_encode([
+            'id' => 're_test_retry',
+            'object' => 'refund',
+            'payment_intent' => 'pi_test_retry',
+            'status' => 'succeeded',
+        ]));
+
+        $this->gateway->refund('cs_test_ref', 'pi_test_retry', 10.50);
+
+        $refundRequest = MockHttpClient::getAllRequests()[1];
+        $this->assertSame(2, $refundRequest['configuredMaxNetworkRetries']);
+        $idempotencyKey = $this->getIdempotencyKey($refundRequest['headers']);
+        $this->assertMatchesRegularExpression(
+            '/^blesta-refund-[a-f0-9]{32}$/',
+            $idempotencyKey
+        );
+        $this->assertSame(0, \Stripe\Stripe::getMaxNetworkRetries());
+    }
+
+    public function testEqualPartialRefundAttemptsUseDifferentIdempotencyKeys()
+    {
+        foreach (['one', 'two'] as $suffix) {
+            MockHttpClient::enqueueResponse(json_encode([
+                'id' => 'pi_test_equal_partial',
+                'object' => 'payment_intent',
+                'currency' => 'usd',
+            ]));
+            MockHttpClient::enqueueResponse(json_encode([
+                'id' => 're_test_equal_partial_' . $suffix,
+                'object' => 'refund',
+                'payment_intent' => 'pi_test_equal_partial',
+                'status' => 'succeeded',
+            ]));
+        }
+
+        $this->gateway->refund('cs_test_ref', 'pi_test_equal_partial', 5.25);
+        $this->gateway->refund('cs_test_ref', 'pi_test_equal_partial', 5.25);
+
+        $requests = MockHttpClient::getAllRequests();
+        $this->assertSame(525, $requests[1]['params']['amount']);
+        $this->assertSame(525, $requests[3]['params']['amount']);
+        $this->assertNotSame(
+            $this->getIdempotencyKey($requests[1]['headers']),
+            $this->getIdempotencyKey($requests[3]['headers'])
+        );
+    }
+
+    private function getIdempotencyKey(array $headers)
+    {
+        foreach ($headers as $header) {
+            if (strpos($header, 'Idempotency-Key: ') === 0) {
+                return substr($header, strlen('Idempotency-Key: '));
+            }
+        }
+
+        $this->fail('Stripe request did not include an idempotency key.');
+    }
+
     public function testRefundApiError()
     {
         // PaymentIntent::retrieve succeeds (needs currency for formatAmount)
@@ -118,6 +183,7 @@ class RefundTest extends TestCase
 
         $errors = $this->gateway->Input->errors();
         $this->assertArrayHasKey('api', $errors);
+        $this->assertSame(0, \Stripe\Stripe::getMaxNetworkRetries());
 
         // Verify error was logged with success=false
         $logs = $this->gateway->getLogEntries();

--- a/tests/Unit/VoidTest.php
+++ b/tests/Unit/VoidTest.php
@@ -8,16 +8,25 @@ use PHPUnit\Framework\TestCase;
 class VoidTest extends TestCase
 {
     private $gateway;
+    private $originalMaxNetworkRetries;
 
     protected function setUp(): void
     {
         class_exists(\Stripe\Stripe::class);
+
+        $this->originalMaxNetworkRetries = \Stripe\Stripe::getMaxNetworkRetries();
+        \Stripe\Stripe::setMaxNetworkRetries(1);
 
         MockHttpClient::reset();
         \Stripe\ApiRequestor::setHttpClient(new MockHttpClient());
         $this->gateway = new StripeUniversal();
         $this->gateway->setMeta(['secret_key' => 'sk_test_123']);
         // No setCurrency() needed — void() does not convert amounts
+    }
+
+    protected function tearDown(): void
+    {
+        \Stripe\Stripe::setMaxNetworkRetries($this->originalMaxNetworkRetries);
     }
 
     public function testVoidSuccess()
@@ -67,7 +76,7 @@ class VoidTest extends TestCase
             '/^blesta-refund-[a-f0-9]{32}$/',
             $idempotencyKey
         );
-        $this->assertSame(0, \Stripe\Stripe::getMaxNetworkRetries());
+        $this->assertSame(1, \Stripe\Stripe::getMaxNetworkRetries());
     }
 
     private function getIdempotencyKey(array $headers)
@@ -96,7 +105,7 @@ class VoidTest extends TestCase
 
         $errors = $this->gateway->Input->errors();
         $this->assertArrayHasKey('api', $errors);
-        $this->assertSame(0, \Stripe\Stripe::getMaxNetworkRetries());
+        $this->assertSame(1, \Stripe\Stripe::getMaxNetworkRetries());
 
         // Verify error was logged with success=false
         $logs = $this->gateway->getLogEntries();

--- a/tests/Unit/VoidTest.php
+++ b/tests/Unit/VoidTest.php
@@ -49,6 +49,38 @@ class VoidTest extends TestCase
         $this->assertArrayNotHasKey('amount', $requests[0]['params']);
     }
 
+    public function testVoidConfiguresRequestScopedIdempotencyAndRetries()
+    {
+        MockHttpClient::enqueueResponse(json_encode([
+            'id' => 're_test_void_retry',
+            'object' => 'refund',
+            'payment_intent' => 'pi_test_void_retry',
+            'status' => 'succeeded',
+        ]));
+
+        $this->gateway->void('cs_test_ref', 'pi_test_void_retry');
+
+        $voidRequest = MockHttpClient::getAllRequests()[0];
+        $this->assertSame(2, $voidRequest['configuredMaxNetworkRetries']);
+        $idempotencyKey = $this->getIdempotencyKey($voidRequest['headers']);
+        $this->assertMatchesRegularExpression(
+            '/^blesta-refund-[a-f0-9]{32}$/',
+            $idempotencyKey
+        );
+        $this->assertSame(0, \Stripe\Stripe::getMaxNetworkRetries());
+    }
+
+    private function getIdempotencyKey(array $headers)
+    {
+        foreach ($headers as $header) {
+            if (strpos($header, 'Idempotency-Key: ') === 0) {
+                return substr($header, strlen('Idempotency-Key: '));
+            }
+        }
+
+        $this->fail('Stripe request did not include an idempotency key.');
+    }
+
     public function testVoidApiError()
     {
         MockHttpClient::enqueueResponse(json_encode([
@@ -64,6 +96,7 @@ class VoidTest extends TestCase
 
         $errors = $this->gateway->Input->errors();
         $this->assertArrayHasKey('api', $errors);
+        $this->assertSame(0, \Stripe\Stripe::getMaxNetworkRetries());
 
         // Verify error was logged with success=false
         $logs = $this->gateway->getLogEntries();


### PR DESCRIPTION
## Summary
- add a request-scoped Stripe idempotency key to refund and void refund creation
- configure at least two Stripe network retries during each refund creation and restore the prior static SDK setting in finally
- cover request key configuration, restoration after success and API failures, and distinct equal-value partial refunds

## Why the temporary SDK setting
Stripe PHP 21's legacy static Refund::create path parses request options but does not forward max_network_retries to ApiRequestor. Its CurlClient instead reads Stripe::getMaxNetworkRetries(), so the gateway scopes that setting to each Refund::create call and restores it afterward.

## Scope and residual risk
Blesta's NonmerchantGateway refund/void callbacks provide only the original reference and transaction IDs, amount, and notes. They do not provide a persistent refund-attempt ID. This change protects ambiguous failures retried by Stripe within one gateway invocation; a separate later Blesta retry receives a new key so legitimate equal-value partial refunds are never conflated. Operators must reconcile an ambiguous completed invocation in Stripe before retrying it manually.

## Verification
- PHPUnit: 78 tests, 192 assertions (PHP 8.2; existing test-stub dynamic-property deprecation notices only)
- PHPStan: clean
- PHP CS Fixer dry run: clean
- PHP syntax checks: clean